### PR TITLE
print null objects as empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = function(parameters) {
   var config = {
     escape: false, // don't escape HTML
   };
-  return (new Velocity.Compile(ast, config)).render(data);
+  return (new Velocity.Compile(ast, config)).render(data, null, true);
 };
 
 // Workaround to followings

--- a/test/input.js
+++ b/test/input.js
@@ -2,6 +2,13 @@ var assert = require('assert');
 var mappingTemplate = require('../');
 
 describe('$input', function() {
+  describe('null object references', function () {
+    it('render as empty string', function() {
+      assert.equal(mappingTemplate({template: '$input.path("$").item1', payload: '{"item1":"hello world"}'}), 'hello world');
+      assert.equal(mappingTemplate({template: '$input.path("$").item2', payload: '{"item1":"hello world"}'}), '');
+    });
+  });
+
   describe('.path(x)', function () {
     it('returns object at x(JSON Path) in payload', function() {
       assert.equal(mappingTemplate({template: '$input.path("$")', payload: "toqoz"}), 'toqoz');


### PR DESCRIPTION
api gateway prints null objects as empty string, use velocityjs "silence" option to get the same result

Fixes Issue https://github.com/ToQoz/api-gateway-mapping-template/issues/5