### PR TITLE
fix escapeJavaScript for quotes: double escape the double quote

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ function base64Decode(x) {
 //   http://www.ecma-international.org/ecma-262/6.0/index.html#sec-quotejsonstring
 //   DO: 2.a -> 2.b -> 2.c -> 2.d
 var escapeJavaScriptTable = {
-  '"': '\"',    // 2.a
+   '"': '\\"',    // 2.a
   '\\': '\\\\',
   '\b': '\\b',  // 2.b (skip abbrev)
   '\f': '\\f',

--- a/test/util.js
+++ b/test/util.js
@@ -3,11 +3,25 @@ var mappingTemplate = require('../');
 
 describe('$util', function() {
   describe('.escapeJavaScript()', function() {
-    it ('escapes as javascript string', function() {
-      var template = '$util.escapeJavaScript($input.path(\'$\'))';
-      var result = mappingTemplate({template: template, payload: 'bo"dy'});
+    var template = '$util.escapeJavaScript($input.path(\'$\'))';
+    var result = mappingTemplate({template: template, payload: 'bo"dy'});
+    it ('escapes as javascript string - simple - ${result}', function() {
       assert.equal(result, 'bo\"dy');
     });
+    var doc = `{"foo":"${result}"}`;
+    it (`escapes as javascript string - parse stringify doc - ${doc}`, function() {
+      // this truly tests whether it is embeddable 
+      var p1 = JSON.parse(doc); // this will fail if not escaped properly
+      var s1 = JSON.stringify(p1);
+      assert.equal(s1, doc);
+    });
+    it (`escapes as javascript string - stringify parse doc - ${doc}`, function() {
+      // this is tautological - it should work always
+      var s2 = JSON.stringify(doc);
+      var p2 = JSON.parse(s2);
+      assert.equal(p2, doc);
+    });
+
   });
   describe('.urlEncode()', function() {
     it ('encodes to url', function() {

--- a/test/util.js
+++ b/test/util.js
@@ -5,8 +5,8 @@ describe('$util', function() {
   describe('.escapeJavaScript()', function() {
     var template = '$util.escapeJavaScript($input.path(\'$\'))';
     var result = mappingTemplate({template: template, payload: 'bo"dy'});
-    it ('escapes as javascript string - simple - ${result}', function() {
-      assert.equal(result, 'bo\"dy');
+    it (`escapes as javascript string - simple - ${result}`, function() {
+      assert.equal(result, 'bo\\"dy');
     });
     var doc = `{"foo":"${result}"}`;
     it (`escapes as javascript string - parse stringify doc - ${doc}`, function() {


### PR DESCRIPTION
ref: https://github.com/ToQoz/api-gateway-mapping-template/issues/8

double quote the string used in `util.escapeJsonString`.

Note, I notice the existing test - https://github.com/jlongman/api-gateway-mapping-template/blob/master/test/util.js#L5 - this would presumably break this test? I may add the test in the original issue to the PR.

Thinking about this, maybe this suggests a difference in runtime environments?  Will add notes to the issue.