### PR TITLE
Upgrade velocityJS to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "JSONPath": "^0.11.2",
     "clone": "^1.0.2",
-    "velocityjs": "^0.7.4"
+    "velocityjs": "^2.0.6"
   },
   "devDependencies": {
     "adm-zip": "^0.4.7",

--- a/test/fixtures/complexExpectedOutput.js
+++ b/test/fixtures/complexExpectedOutput.js
@@ -1,0 +1,53 @@
+module.exports = [
+    {
+        status: 'TO_DELIVER',
+        client: {
+            name: 'AClient',
+            id: '9da8ca23-7508-4b0b-98c5-6d198562d76e',
+        },
+        rentalPeriod: {
+            id: '12bec83f-1ab2-4ec6-9238-b7c06799c530',
+        },
+        contract: {
+            id: '33d21c93-62c3-475d-aabf-ede4a8b22038',
+            amendments: [
+                {
+                    id: "7036793c-e00f-4aa2-a187-51c060e4c4e2",
+                    options: [
+                        {name: "4 summer tires"}
+                    ]
+                }
+            ],
+            order: {
+                id: 'b0ad6ddb-6cf1-4413-abd5-7f14f86d9536',
+                options: [],
+            },
+        },
+        model: {
+            id: '98e6426b-6b07-4562-be32-f5859d343984',
+        },
+    },
+    {
+        status: 'TO_DELIVER',
+        client: {
+            name: 'AnotherClient',
+            id: '9da8ca23-7508-4b0b-98c5-6d198562d76e',
+        },
+        rentalPeriod: {
+            id: '12bec83f-1ab2-4ec6-9238-b7c06799c530',
+        },
+        contract: {
+            id: '33d21c93-62c3-475d-aabf-ede4a8b22038',
+            amendments: [],
+            order: {
+                id: 'b0ad6ddb-6cf1-4413-abd5-7f14f86d9536',
+                options: [
+                    {name: "4 summer tires"}
+                ],
+            },
+        },
+        model: {
+            id: 'a9f14adc-5306-42a4-891a-d799198095af',
+        },
+    }
+]

--- a/test/fixtures/complexInput.json
+++ b/test/fixtures/complexInput.json
@@ -1,0 +1,99 @@
+{
+  "Items": [
+    {
+      "clientId": {
+        "S": "9da8ca23-7508-4b0b-98c5-6d198562d76e"
+      },
+      "sk": {
+        "S": "RP#33d21c93-62c3-475d-aabf-ede4a8b22038#12bec83f-1ab2-4ec6-9238-b7c06799c530"
+      },
+      "clientName": {
+        "S": "AClient"
+      },
+      "amendments": {
+        "L": [
+          {
+            "M": {
+              "id": {
+                "S": "7036793c-e00f-4aa2-a187-51c060e4c4e2"
+              },
+              "options": {
+                "L": [
+                  {
+                    "M": {
+                      "name": {
+                        "S": "4 summer tires"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "status": {
+        "S": "TO_DELIVER"
+      },
+      "carModel": {
+        "M": {
+          "id": {
+            "S": "98e6426b-6b07-4562-be32-f5859d343984"
+          }
+        }
+      },
+      "order": {
+        "M": {
+          "options": {
+            "L": []
+          },
+          "id": {
+            "S": "b0ad6ddb-6cf1-4413-abd5-7f14f86d9536"
+          }
+        }
+      }
+    },
+    {
+      "clientId": {
+        "S": "9da8ca23-7508-4b0b-98c5-6d198562d76e"
+      },
+      "sk": {
+        "S": "RP#33d21c93-62c3-475d-aabf-ede4a8b22038#12bec83f-1ab2-4ec6-9238-b7c06799c530"
+      },
+      "clientName": {
+        "S": "AnotherClient"
+      },
+      "amendments": {
+        "L": []
+      },
+      "status": {
+        "S": "TO_DELIVER#1645022598375"
+      },
+      "carModel": {
+        "M": {
+          "id": {
+            "S": "a9f14adc-5306-42a4-891a-d799198095af"
+          }
+        }
+      },
+      "order": {
+        "M": {
+          "options": {
+            "L": [
+              {
+                "M": {
+                  "name": {
+                    "S": "4 summer tires"
+                  }
+                }
+              }
+            ]
+          },
+          "id": {
+            "S": "b0ad6ddb-6cf1-4413-abd5-7f14f86d9536"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/complexMapping.js
+++ b/test/fixtures/complexMapping.js
@@ -1,0 +1,43 @@
+module.exports = `
+#set($inputRoot = $input.path('$.Items'))
+[
+#foreach($car in $inputRoot)
+{
+  "status": "$car.status.S.split('#')[0]",
+  "client": {
+    "name": "$car.clientName.S",
+    "id": "$car.clientId.S"
+  },
+  "rentalPeriod": {
+    "id": "$car.sk.S.split('#')[2]"
+  },
+  "contract": {
+    "id": "$car.sk.S.split('#')[1]",
+    "amendments": [
+      #foreach($amendment in $car.amendments.L) {
+        "id": "$amendment.M.id.S",
+        "options": [
+          #foreach($option in $amendment.M.options.L) {
+            "name": "$option.M.name.S"
+            }#if($foreach.hasNext),#end
+          #end
+        ]
+      }#if($foreach.hasNext),#end
+    #end
+    ],
+    "order": {
+      "id": "$car.order.M.id.S",
+      "options": [
+        #foreach($option in $car.order.M.options.L) {
+          "name": "$option.M.name.S"
+          }#if($foreach.hasNext),#end
+        #end
+      ]
+    }
+  },
+  "model": {
+    "id": "$car.carModel.M.id.S"
+  }
+}#if($foreach.hasNext),#end
+#end
+]`

--- a/test/input.js
+++ b/test/input.js
@@ -1,5 +1,9 @@
 var assert = require('assert');
 var mappingTemplate = require('../');
+const fs = require("fs");
+const path = require("path");
+const complexTemplate = require("./fixtures/complexMapping");
+const complexExpectedOutput = require("./fixtures/complexExpectedOutput");
 
 describe('$input', function() {
   describe('null object references', function () {
@@ -105,6 +109,14 @@ describe('$input', function() {
           assert.equal(result, '{"NAME": "TOQOZ", "AGE": "999"}');
         });
       });
+    });
+  });
+
+  describe('Complex example', function () {
+    it('Handle nested foreach', function () {
+      const payload = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'complexInput.json'))
+      const result = mappingTemplate({template: complexTemplate, payload});
+      assert.deepEqual(JSON.parse(result), complexExpectedOutput);
     });
   });
 });


### PR DESCRIPTION
Older version has a bug when trying to use complex mapping template with nested #foreach (see added test case).

I found this issue while using this package to unit test api gateway integration mapping. Upgrading VelocityJs version seems to fix the issue. 